### PR TITLE
Force Tesla P100 for Colab Free

### DIFF
--- a/Colab-RIFE.ipynb
+++ b/Colab-RIFE.ipynb
@@ -7,7 +7,8 @@
       "provenance": [],
       "private_outputs": true,
       "collapsed_sections": [],
-      "toc_visible": true
+      "toc_visible": true,
+	  "machine_shape":"hm"
     },
     "kernelspec": {
       "name": "python3",


### PR DESCRIPTION
This will avoid getting a Tesla K80 or T4 when running the notebook on Colab Free.

On Colab Pro, it will either give you a P100 or V100.